### PR TITLE
Used abstract type `AbstractMatrix` in encoding

### DIFF
--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -1,5 +1,5 @@
 function encode(
-    image::Matrix{TColor}; quality::Union{Int, Nothing} = nothing, transpose = false
+    image::AbstractMatrix{TColor}; quality::Union{Int, Nothing} = nothing, transpose = false
 )::Vector{UInt8} where {TColor <: Colorant}
     lossy = !isnothing(quality)
     if TColor == BGR{N0f8}


### PR DESCRIPTION
The PR fixes the error:
```julia
julia> x = Float16.(channelview(rand(RGB{N0f8}, 180, 320)))

julia> WebP.encode(colorview(RGB, N0f8.(x)))
ERROR: MethodError: no method matching encode(::Base.ReinterpretArray{RGB{N0f8}, 2, N0f8, Array{N0f8, 3}, true})

Closest candidates are:
  encode(::Matrix{TColor}; quality, transpose) where TColor<:Colorant
   @ WebP ~/.julia/packages/WebP/G4Y4q/src/encoding.jl:1

Stacktrace:
 [1] top-level scope
   @ REPL[34]:1
```