### PR TITLE
fix: quality in encoding

### DIFF
--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -2,6 +2,9 @@ function encode(
     image::AbstractMatrix{TColor}; quality::Union{Int, Nothing} = nothing, transpose = false
 )::Vector{UInt8} where {TColor <: Colorant}
     lossy = !isnothing(quality)
+    if lossy && !(0 ≤ quality ≤ 100)
+        throw(ArgumentError("Quality $quality is not in the range from 0 to 100."))
+    end
     if TColor == BGR{N0f8}
         webp_encode_fn = lossy ? Wrapper.WebPEncodeBGR : Wrapper.WebPEncodeLosslessBGR
     elseif TColor == BGRA{N0f8}
@@ -22,7 +25,7 @@ function encode(
     stride = width * sizeof(TColor)
     output_ptr = Ref{Ptr{UInt8}}()
     if lossy
-        quality_factor = quality / 100.0f0
+        quality_factor = Float32(quality)
         output_length = webp_encode_fn(
             pointer(image), width, height, stride, quality_factor, output_ptr
         )

--- a/test/encoding_tests.jl
+++ b/test/encoding_tests.jl
@@ -26,6 +26,10 @@ using WebP
             end
 
             @testset "Lossy" begin
+                @testset "encode throws ArgumentError for quality outside range" begin
+                    @test_throws ArgumentError WebP.encode(input_image; quality = -1)
+                    @test_throws ArgumentError WebP.encode(input_image; quality = 101)
+                end
                 qualities = [1, 10, 50, 100]
                 for quality in qualities
                     input_kwargs = merge(kwargs, (quality = quality,))


### PR DESCRIPTION
This PR fixes the following issues:

1. `WebP.encode` with `quality=100` followed by `WebP.decode` returns a low quality image:
```julia
image_original = testimage("lighthouse")
x = WebP.encode(image_orignal; quality=100)
image_webp = WebP.decode(x)
```
Original:
![image_rgb](https://github.com/stemann/WebP.jl/assets/5800038/fad910b4-1862-4ed7-aea5-2fc2b1c708ff)
WebP:
![image_rgb_webp](https://github.com/stemann/WebP.jl/assets/5800038/502d9934-b581-40c8-be1a-97627a009248)

2. Segmentation fault occurs when [`quality` is outside the range of 0 to 100](https://developers.google.com/speed/webp/docs/api#simple_encoding_api).
```julia
julia> x = WebP.encode(image_orignal; quality=-100)
[41774] signal (11.1): Segmentation fault
in expression starting at REPL[6]:1
cfree at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
WebPSafeFree at /home/ymtoo/.julia/artifacts/b0dd47a5c6466709af32a1dfd76d973073ec07e6/lib/libwebp.so (unknown line)
WebPFree at /home/ymtoo/.julia/artifacts/b0dd47a5c6466709af32a1dfd76d973073ec07e6/lib/libwebp.so (unknown line)
WebPFree at /home/ymtoo/.julia/packages/WebP/FKArR/src/Wrapper.jl:960 [inlined]
#encode#5 at /home/ymtoo/.julia/packages/WebP/FKArR/src/encoding.jl:34
encode at /home/ymtoo/.julia/packages/WebP/FKArR/src/encoding.jl:1
unknown function (ip: 0x7fe326d3cbd9)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:2894 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:3076
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/julia.h:1982 [inlined]
do_call at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/interpreter.c:126
eval_value at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/interpreter.c:223
eval_stmt_value at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/interpreter.c:174 [inlined]
eval_body at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/interpreter.c:617
jl_interpret_toplevel_thunk at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/interpreter.c:775
jl_toplevel_eval_flex at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/toplevel.c:934
jl_toplevel_eval_flex at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/toplevel.c:877
jl_toplevel_eval_flex at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/toplevel.c:877
jl_toplevel_eval_flex at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/toplevel.c:877
ijl_toplevel_eval_in at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/toplevel.c:985
eval at ./boot.jl:385 [inlined]
eval_user_input at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:150
repl_backend_loop at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:246
#start_repl_backend#46 at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:231
start_repl_backend at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:228
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:2894 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:3076
#run_repl#59 at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:389
run_repl at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:375
jfptr_run_repl_91745.1 at /home/ymtoo/julia-1.10.2/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:2894 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:3076
#1013 at ./client.jl:432
jfptr_YY.1013_82712.1 at /home/ymtoo/julia-1.10.2/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:2894 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:3076
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/julia.h:1982 [inlined]
jl_f__call_latest at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/builtins.c:812
#invokelatest#2 at ./essentials.jl:892 [inlined]
invokelatest at ./essentials.jl:889 [inlined]
run_main_repl at ./client.jl:416
exec_options at ./client.jl:333
_start at ./client.jl:552
jfptr__start_82738.1 at /home/ymtoo/julia-1.10.2/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:2894 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/gf.c:3076
jl_apply at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/julia.h:1982 [inlined]
true_main at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/jlapi.c:582
jl_repl_entrypoint at /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/src/jlapi.c:731
main at julia (unknown line)
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x4010b8)
Allocations: 11075677 (Pool: 11064037; Big: 11640); GC: 18
Segmentation fault (core dumped)
```